### PR TITLE
fix: 复制引用对象，避免移动图形时出现异常

### DIFF
--- a/paintweb/www/creator/path.js
+++ b/paintweb/www/creator/path.js
@@ -56,7 +56,7 @@ class QPathCreator {
     onkeydown(event) {
         switch (event.keyCode) {
         case 13: // keyEnter
-            this.points.push(this.toPos)
+            this.points.push(Object.assign({}, this.toPos))
             this.ondblclick(event)
             break
         case 27: // keyEsc


### PR DESCRIPTION
现象：绘制路径图形时，如果最后一个点点击后，原地不动鼠标，再使用回车结束绘图，之后再移动图形，图形会变形。

原因分析：如果最后一个点点击后，原地不动鼠标，再使用回车结束绘图，点的数组里的最后两个点将是同一个对象，在进行图形移动时，移动的偏移量将会编译两次，导致图形变形。

解决方案：通过对象复制，保证路径中的点都是不同的对象。